### PR TITLE
Fix the snapshot version number to 999.9.9

### DIFF
--- a/src/main/kotlin/mb/gitonium/GitoniumPlugin.kt
+++ b/src/main/kotlin/mb/gitonium/GitoniumPlugin.kt
@@ -43,7 +43,7 @@ open class GitoniumExtension(private val project: Project) {
     val releaseTagVersion = releaseTagVersion // Assign to local val to enable smart cast.
     when {
       releaseTagVersion != null -> releaseTagVersion
-      branch != null -> "$branch-SNAPSHOT"
+      branch != null -> "999.9.9-$branch-SNAPSHOT"
       else -> {
         project.logger.info("Gitonium cannot set the version for $project; the repository HEAD does not point to a branch, nor a release tag. Defaulting to '${Project.DEFAULT_VERSION}'")
         Project.DEFAULT_VERSION


### PR DESCRIPTION
This prefixes `SNAPSHOT` versions with a high version number, such that they will be picked by Gradle over an existing release.

Upside of this approach:
- very simple
- Gradle will pick the most recent snapshot when specifying `latest.integration` as the dependency version

Some downsides of this approach are:
- the version number is just arbitrarily high, and has no relation with any existing versions
- the high version number prevents newer release dependencies (e.g. in Eclipse) from overriding older snapshot dependencies
- the ordering between two snapshots of different branches is not clear (e.g., `999.9.9-develop-SNAPSHOT` vs `999.9.9-my-feature-SNAPSHOT`)
- of course, if we ever hit version 999.9.9, this approach fails

This is a possible fix for #1.

Alternatively, we could spend some effort to have snapshot version numbers align with release version numbers, by taking the most recent Git tag into account. It is not clear whether this is worth the effort.

Note: PR #2 was erroneously made against `master` instead of `develop`.